### PR TITLE
docs: add HIPAA, DORA, and FedRAMP compliance mappings

### DIFF
--- a/.claude/agents/grc-analyst.md
+++ b/.claude/agents/grc-analyst.md
@@ -29,7 +29,9 @@ Maintain awareness of applicable controls from:
 - **PCI DSS v4.0** (if payment card data is in scope)
 - **OWASP ASVS** (as the technical requirements anchor)
 - **GDPR / UK GDPR** (if personal data is processed)
-- **DORA** (if applicable to financial services)
+- **HIPAA** (Security & Privacy Rules — if protected health information is in scope)
+- **DORA** (if applicable to EU financial services)
+- **FedRAMP** (NIST SP 800-53 baseline — if selling to US federal agencies)
 
 ---
 
@@ -54,10 +56,14 @@ When invoked at the start of a project or feature:
 ```markdown
 ## Control Mapping
 
-| ASVS Ref | Requirement | SOC 2 | ISO 27001 | NIST CSF | PCI DSS |
-|----------|-------------|-------|-----------|----------|---------|
-| V2.1.1 | Password complexity | CC6.1 | A.8.5 | PR.AC-1 | Req 8.3 |
-| V6.1.1 | Encryption at rest | CC6.7 | A.8.24 | PR.DS-1 | Req 3.5 |
+| ASVS Ref | Requirement | SOC 2 | ISO 27001 | NIST CSF | PCI DSS | HIPAA | DORA | FedRAMP |
+|----------|-------------|-------|-----------|----------|---------|-------|------|---------|
+| V2.1.1 | Password complexity | CC6.1 | A.8.5 | PR.AC-1 | Req 8.3 | §164.312(d) | Art. 9 | IA-5 |
+| V6.1.1 | Encryption at rest | CC6.7 | A.8.24 | PR.DS-1 | Req 3.5 | §164.312(a)(2)(iv) | Art. 9 | SC-28 |
+
+> Only populate columns for frameworks selected in `secure-sdlc.yaml`. Add HIPAA when
+> protected health information is processed, DORA for EU financial entities, and FedRAMP
+> (NIST SP 800-53 control families: AC, AU, IA, SC, …) when targeting US federal agencies.
 ```
 
 ---

--- a/docs/templates/compliance-attestation.md
+++ b/docs/templates/compliance-attestation.md
@@ -3,7 +3,7 @@
 **Release version:** v[X.Y.Z]
 **Date:** [YYYY-MM-DD]
 **Author:** GRC Analyst Agent + [Human GRC lead]
-**Frameworks in scope:** [SOC 2 / ISO 27001 / NIST CSF / PCI DSS / GDPR — delete inapplicable]
+**Frameworks in scope:** [SOC 2 / ISO 27001 / NIST CSF / PCI DSS / GDPR / HIPAA / DORA / FedRAMP — delete inapplicable]
 **Status:** Draft / Review / Approved
 
 ---
@@ -107,6 +107,45 @@ ISO/IEC 27001:2022 Annex A, NIST CSF 2.0]
 | Art. 25 | Data protection by design and by default | | | |
 | Art. 32 | Security of processing | | | |
 | Art. 33/34 | Breach notification capability | | | |
+
+---
+
+### HIPAA *(complete only if protected health information (PHI) is in scope)*
+
+| Standard / Rule | Safeguard | Status | Evidence Reference | Notes |
+|-----------------|-----------|--------|--------------------|-------|
+| §164.308(a)(1) | Security Rule — Security management process (risk analysis) | ✅ Met / ⚠️ Gap / 🚫 Fail | | |
+| §164.312(a)(1) | Security Rule — Access control (technical safeguards) | | | |
+| §164.312(b) | Security Rule — Audit controls | | | |
+| §164.312(e)(1) | Security Rule — Transmission security (encryption in transit) | | | |
+| §164.502(b) | Privacy Rule — Minimum necessary use and disclosure | | | |
+
+*Extend with additional Security/Privacy Rule standards (e.g. §164.308 administrative, §164.310 physical) relevant to the systems in scope.*
+
+---
+
+### DORA *(complete only if an EU financial entity or critical ICT third-party provider)*
+
+| Article / Pillar | Requirement | Status | Evidence Reference | Notes |
+|------------------|-------------|--------|--------------------|-------|
+| Art. 5–15 | ICT risk management framework | ✅ Met / ⚠️ Gap / 🚫 Fail | | |
+| Art. 17–23 | ICT-related incident management, classification & reporting | | | |
+| Art. 24–27 | Digital operational resilience testing (incl. TLPT) | | | |
+| Art. 28–30 | ICT third-party risk management | | | |
+
+---
+
+### FedRAMP *(complete only if selling to US federal agencies — NIST SP 800-53 baseline)*
+
+| Control Family | Control | Status | Evidence Reference | Notes |
+|----------------|---------|--------|--------------------|-------|
+| AC — Access Control | AC-2 Account management | ✅ Met / ⚠️ Gap / 🚫 Fail | | |
+| AU — Audit & Accountability | AU-2 Event logging | | | |
+| IA — Identification & Authentication | IA-2 Identification and authentication (organisational users) | | | |
+| SC — System & Communications Protection | SC-7 Boundary protection | | | |
+| SC — System & Communications Protection | SC-28 Protection of information at rest | | | |
+
+*Select the impact baseline (Low / Moderate / High) and extend with the corresponding 800-53 control families (CM, CP, IR, RA, SI, …).*
 
 ---
 


### PR DESCRIPTION
Close the gap where the kickoff wizard offered HIPAA/DORA/FedRAMP but the GRC agent and attestation template had no tables for them.

- grc-analyst.md: add HIPAA/FedRAMP to supported frameworks and extend the Control Mapping example with HIPAA/DORA/FedRAMP columns
- compliance-attestation.md: add HIPAA (Security/Privacy Rule), DORA (four pillars), and FedRAMP (AC/AU/IA/SC families) tables matching existing style