### PR TITLE
feat: add Spring Boot stack profile, PR CI, and release v1.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ version: 2.1
 #
 # NOTE: .github/workflows/secure-sdlc-gate.yml is intentionally NOT migrated — it
 # is a product template shipped to end users and uses GitHub-native CodeQL.
+#
+# NOTE: .github/workflows/pr-checks.yml runs these same steps on pull requests.
+# CircleCI skips fork PRs unless "Build forked pull requests" is enabled in Project
+# Settings → Advanced, so fork contributions would otherwise report zero checks.
 
 orbs:
   node: circleci/node@5
@@ -27,6 +31,8 @@ jobs:
       - run:
           name: Install dependencies
           command: npm ci
+      # Kept as separate steps for readable failure output. Contributors run the same
+      # two commands locally via `npm run ci` — keep the three in sync.
       - run:
           name: Run tests
           command: npm test

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "A team of 8 AI security specialists embedded in your coding workflow — covering every phase of the Secure SDLC from requirements to release gating.",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "Kaademos/secure-sdlc-agents"
       },
       "description": "8 AI security specialist agents for the full Secure SDLC: threat modelling, AppSec, GRC, IaC review, AI/LLM security, and release gating. Works with Claude Code, Cursor, Windsurf, and any MCP-compatible tool.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Kaademos"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "secure-sdlc-agents",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A team of AI security specialists embedded in your coding workflow. 8 agents covering every phase of the Secure SDLC: requirements, threat modelling, code review, IaC security, compliance, and release gating. Works with Claude Code, Cursor, Windsurf, and any MCP-compatible tool.",
   "author": {
     "name": "Kaademos",

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,62 @@
+name: PR Checks
+
+# Repository CI for pull requests, including those from forks.
+#
+# WHY THIS EXISTS ALONGSIDE CIRCLECI:
+# .circleci/config.yml is the primary CI for pushes and release tags. CircleCI does
+# not build pull requests from forks unless "Build forked pull requests" is enabled
+# in Project Settings → Advanced, so fork PRs previously reported zero checks and a
+# broken contribution could look green. GitHub Actions runs fork PRs out of the box
+# with a read-only token and no secrets, so this workflow guarantees every PR is
+# validated regardless of project settings.
+#
+# This runs the SAME commands as CircleCI (`npm test`, `npm run test:pack`) on the
+# same Node matrix — keep the two in sync.
+#
+# NOTE: this is repository CI. It is NOT shipped to end users — package.json `files`
+# includes only .github/workflows/secure-sdlc-gate.yml, which is the product template.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+# Least privilege: the suite only needs to read the checked-out tree.
+permissions:
+  contents: read
+
+# A new push to a PR cancels the superseded run.
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["18", "20", "22"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify npm package contents
+        run: npm run test:pack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.3.0] — 2026-07-22
+
+### Added
+- **Spring Boot stack profile** (`stacks/spring-boot.md`) — code-driven security guidance for Spring Boot 3.x / Spring Security 6.x on Java 17+ and Kotlin: Actuator exposure (`/heapdump`, `/env`), filter-chain matcher ordering, `@EnableMethodSecurity`, JPQL/`JdbcTemplate` injection, SpEL injection, mass assignment, Jackson polymorphic deserialisation, Thymeleaf XSS/SSTI, and `allowedOriginPatterns("*")` CORS
+- **Spring Boot security notes** in `getStackSecurityNotes()`, so `secure-sdlc init` and `kickoff` no longer fall back to generic guidance on Spring projects
+- **Test guard** — every shipped `stacks/*.md` must return stack-specific notes rather than the generic fallback, closing the gap that allowed a detectable stack to ship with no guidance behind it
+- **Pull request CI** (`.github/workflows/pr-checks.yml`) — runs the same `npm test` + `npm run test:pack` steps as CircleCI on Node 18/20/22 for every PR **including forks**, which CircleCI skips unless "Build forked pull requests" is enabled. Least-privilege `contents: read` token, actions pinned to full commit SHAs
+- **`npm run ci`** — runs the same two commands CircleCI does, so a change that passes locally passes in CI
+
+### Fixed
+- **Gradle Spring Boot projects were never detected** — `build.gradle`/`build.gradle.kts` always resolved to `java`, so Kotlin and Gradle-based Spring Boot services could not reach the Spring Boot profile. Detection now reads the Gradle build files and matches the `org.springframework.boot` plugin as well as Maven's `spring-boot-starter-*` artifacts
+- **`package-lock.json` version drift** — the lockfile was left at `1.1.0` through the 1.2.0 release because the manifests were bumped by hand; it is now back in step with `package.json`
+
+---
+
 ## [1.2.0] — 2026-06-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ If the project uses one of these stacks, reference the relevant profile in `stac
 | Express.js | `stacks/express.md` |
 | Ruby on Rails | `stacks/rails.md` |
 | Go (net/http, Gin, Echo, Fiber) | `stacks/golang.md` |
+| Spring Boot (Java/Kotlin) | `stacks/spring-boot.md` |
 
 Stack profiles contain framework-specific vulnerability patterns, secure coding examples,
 and recommended libraries. Reference them when the dev-lead or appsec-engineer agents

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,11 +92,21 @@ The project ships a dependency-free test suite (Node's built-in runner). Before 
 
 ```bash
 npm install   # or: npm ci
-npm test
+npm run ci    # runs `npm test` + `npm run test:pack` — the same two steps CircleCI runs
 ```
 
+Use `npm run ci` rather than `npm test` alone: CircleCI also verifies the published package
+contents, so a change that ships a file without listing it in `package.json` `files` passes
+`npm test` locally and still fails CI.
+
 The suite guards version sync across manifests, agent frontmatter, and the
-stack-detection ↔ `stacks/*.md` profile mapping. CircleCI runs it on Node 18, 20, and 22.
+stack-detection ↔ `stacks/*.md` profile mapping. It runs on Node 18, 20, and 22 —
+`engines.node` is `>=18`, so avoid syntax newer than that.
+
+Every pull request, including one opened from a fork, is checked automatically by
+[`.github/workflows/pr-checks.yml`](.github/workflows/pr-checks.yml) on the same Node
+matrix. CircleCI (`.circleci/config.yml`) covers pushes to `main` and release tags.
+If your PR is red, run `npm run ci` locally to reproduce it before pushing a fix.
 
 Maintainers: see [RELEASING.md](RELEASING.md) for how to cut a release.
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Deep, framework-specific security guidance in `stacks/`:
 | Express.js | [`stacks/express.md`](stacks/express.md) — helmet, rate limiting, CSRF, Zod validation |
 | Ruby on Rails | [`stacks/rails.md`](stacks/rails.md) — Brakeman, Pundit, strong parameters, credentials |
 | Go (net/http, Gin, Echo, Fiber) | [`stacks/golang.md`](stacks/golang.md) — html/template XSS, database/sql & GORM injection, CORS, gosec/govulncheck |
+| Spring Boot (Java/Kotlin) | [`stacks/spring-boot.md`](stacks/spring-boot.md) — Actuator exposure, `@EnableMethodSecurity`, JPQL & SpEL injection, mass assignment |
 
 ---
 
@@ -439,7 +440,7 @@ please [open an issue](.github/ISSUE_TEMPLATE/guidance-correction.md).
 See [CONTRIBUTING.md](CONTRIBUTING.md). High-value contributions:
 
 - Additional compliance frameworks (HIPAA, FedRAMP, NIS2)
-- Stack profiles for Go (Gin/Echo), .NET, Java Spring Boot
+- Stack profiles for .NET, Rust, and Laravel
 - More worked examples (OAuth flows, payment processing, AI features)
 - Integration guides for specific SAST/DAST tools
 - Translations of agent prompts

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,8 @@ suite enforces it):
 
 ```bash
 # bump the version in all manifests, then:
-npm test          # 13 tests; version-sync test fails if a manifest is out of step
+npm run ci        # tests + package-contents check; the version-sync test
+                  # fails if any manifest is out of step
 ```
 
 - Add a `## [X.Y.Z] — YYYY-MM-DD` section to [CHANGELOG.md](CHANGELOG.md).

--- a/cli/src/utils/stack-detect.js
+++ b/cli/src/utils/stack-detect.js
@@ -60,13 +60,19 @@ export function detectStack(projectRoot) {
   }
 
   // Java / Kotlin / JVM
-  if (has("pom.xml")) {
-    const pom = readFileSync(join(projectRoot, "pom.xml"), "utf-8");
-    if (pom.includes("spring-boot")) return { name: "spring-boot", display: "Spring Boot", language: "Java/Kotlin" };
-    return { name: "java", display: "Java", language: "Java" };
-  }
-  if (has("build.gradle") || has("build.gradle.kts")) {
-    return { name: "java", display: "Gradle/JVM", language: "Java/Kotlin" };
+  if (has("pom.xml") || has("build.gradle") || has("build.gradle.kts")) {
+    const buildFiles = ["pom.xml", "build.gradle", "build.gradle.kts"].map(f =>
+      has(f) ? readFileSync(join(projectRoot, f), "utf-8") : ""
+    ).join("\n");
+
+    // Maven declares spring-boot-starter-* artifacts; Gradle applies the
+    // org.springframework.boot plugin, which the "spring-boot" substring misses.
+    if (buildFiles.includes("spring-boot") || buildFiles.includes("springframework.boot")) {
+      return { name: "spring-boot", display: "Spring Boot", language: "Java/Kotlin" };
+    }
+    return has("pom.xml")
+      ? { name: "java", display: "Java",       language: "Java" }
+      : { name: "java", display: "Gradle/JVM", language: "Java/Kotlin" };
   }
 
   // Rust
@@ -145,6 +151,14 @@ export function getStackSecurityNotes(stackName) {
       "CORS: set an explicit AllowedOrigins list — never combine wildcard/AllowAllOrigins with AllowCredentials:true",
       "net/http ships no security headers — add CSP, HSTS, X-Content-Type-Options via middleware (e.g. unrolled/secure)",
       "Run gosec (SAST) and govulncheck (vulnerable deps) in CI; hash passwords with bcrypt (cost ≥ 12) or argon2id",
+    ],
+    "spring-boot": [
+      "Actuator: expose only health/info and bind the management port to an internal address — /heapdump and /env leak credentials",
+      "@PreAuthorize is silently inert without @EnableMethodSecurity — confirm it is present before trusting method-level checks",
+      "Request matchers are evaluated in order and the first match wins — specific rules first, ending with anyRequest().authenticated()",
+      "Use derived queries or bound @Query parameters — never concatenate input into EntityManager.createQuery or JdbcTemplate SQL",
+      "Disable CSRF only for stateless bearer-token APIs — never while a session cookie still authenticates the user",
+      "Bind requests to DTOs, never onto JPA entities — @ModelAttribute on an @Entity is mass assignment",
     ],
     terraform: [
       "Pin provider versions with ~> constraints, not latest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kaademos/secure-sdlc",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kaademos/secure-sdlc",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaademos/secure-sdlc",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Secure SDLC agent team — CLI to scaffold docs, hooks, CI, and MCP-ready security workflows",
   "type": "module",
   "bin": {
@@ -30,7 +30,8 @@
     "prepack": "node cli/bin/secure-sdlc.js --version",
     "sdlc": "node cli/bin/secure-sdlc.js",
     "test": "node --test test/*.test.js",
-    "test:pack": "npm pack --dry-run --ignore-scripts 2>&1"
+    "test:pack": "npm pack --dry-run --ignore-scripts 2>&1",
+    "ci": "npm test && npm run test:pack"
   },
   "keywords": [
     "security",

--- a/stacks/spring-boot.md
+++ b/stacks/spring-boot.md
@@ -1,0 +1,436 @@
+# Spring Boot Security Profile
+
+**Frameworks:** Spring Boot 3.x, Spring Security 6.x
+**Languages:** Java 17+ / Kotlin 1.9+
+**ASVS Baseline:** L2
+
+---
+
+## Spring Security Is Secure Until You Opt Out
+
+Add `spring-boot-starter-security` and every endpoint is authenticated, CSRF is on, and a
+baseline set of security headers is sent. Almost every real Spring Boot finding comes from
+*opting out* of that: widening Actuator exposure, adding `permitAll()` in the wrong order,
+disabling CSRF while still using cookie sessions, dropping to `EntityManager.createQuery`
+with string concatenation, or binding requests straight onto JPA entities. This profile
+targets those opt-outs, plus the Spring-specific injection classes (SpEL, Thymeleaf) that
+have no equivalent in other stacks.
+
+---
+
+## Actuator — The Most Exploited Spring Boot Misconfiguration
+
+Spring Boot 3.x exposes only `/actuator/health` over HTTP by default. Widening that is the
+single most common way Spring services leak credentials.
+
+```yaml
+# ✗ Critical — exposes heapdump, env, threaddump, mappings, loggers to anyone who can reach the port
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+```
+
+| Endpoint | What an attacker gets |
+|----------|----------------------|
+| `/actuator/heapdump` | Full heap image — DB passwords, session tokens, API keys in memory |
+| `/actuator/env`, `/configprops` | Config values; masking is **key-pattern based** and misses custom names |
+| `/actuator/mappings` | Complete route inventory, including endpoints not meant to be discoverable |
+| `/actuator/loggers` | `POST` changes log levels at runtime — useful for hiding activity |
+| `/actuator/threaddump` | Stack traces revealing internals and in-flight arguments |
+
+```yaml
+# ✓ Expose the minimum, and move management to an internal-only port
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: when-authorized   # never "always" on an internet-facing service
+  server:
+    port: 9001
+    address: 127.0.0.1                # not reachable from outside the host
+```
+
+```java
+// ✓ If Actuator must share the main port, authorise it explicitly
+http.authorizeHttpRequests(auth -> auth
+    .requestMatchers(EndpointRequest.to("health", "info")).permitAll()
+    .requestMatchers(EndpointRequest.toAnyEndpoint()).hasRole("OPS")
+    .anyRequest().authenticated());
+```
+
+---
+
+## Authorisation — Order Matters, and `@PreAuthorize` Needs Enabling
+
+Request matchers are evaluated **in declaration order and the first match wins**. A broad
+rule placed early silently shadows every rule after it.
+
+```java
+// ✗ Unsafe — the /api/** rule matches first, so the admin rule is never reached
+http.authorizeHttpRequests(auth -> auth
+    .requestMatchers("/api/**").permitAll()
+    .requestMatchers("/api/admin/**").hasRole("ADMIN")
+    .anyRequest().authenticated());
+
+// ✓ Safe — most specific first, default-deny last
+http.authorizeHttpRequests(auth -> auth
+    .requestMatchers("/api/admin/**").hasRole("ADMIN")
+    .requestMatchers("/api/public/**").permitAll()
+    .anyRequest().authenticated());   // never end with anyRequest().permitAll()
+```
+
+**`@PreAuthorize` is inert without `@EnableMethodSecurity`.** This is the highest-impact
+trap in the framework: the annotations read as enforcement, compile fine, and do nothing.
+Spring Security 6 replaced `@EnableGlobalMethodSecurity(prePostEnabled = true)` with:
+
+```java
+@Configuration
+@EnableMethodSecurity   // ✓ required — prePost is enabled by default in Spring Security 6
+public class SecurityConfig { }
+```
+
+`hasRole("ADMIN")` checks for the authority `ROLE_ADMIN`; `hasAuthority("ADMIN")` checks the
+literal string. Mixing the two produces a check that can never pass — or a role that is
+never enforced.
+
+### Object-level authorisation (IDOR)
+
+Authenticating the caller says nothing about whether this row is theirs. Spring Data's
+`findById` will happily return another tenant's record.
+
+```java
+// ✗ IDOR — any authenticated user can read any invoice by guessing an id
+@GetMapping("/invoices/{id}")
+public Invoice get(@PathVariable Long id) {
+    return repository.findById(id).orElseThrow();
+}
+
+// ✓ Scope the query to the principal — enforcement in the query, not after it
+@GetMapping("/invoices/{id}")
+public Invoice get(@PathVariable Long id, @AuthenticationPrincipal UserDetails user) {
+    return repository.findByIdAndOwnerUsername(id, user.getUsername())
+        .orElseThrow(() -> new ResponseStatusException(NOT_FOUND)); // 404, not 403
+}
+```
+
+> `@AuthenticationPrincipal` is a Spring MVC argument resolver — it works on **controller**
+> methods. On a service-layer method it resolves to `null`. Pass the principal down, or read
+> `SecurityContextHolder.getContext().getAuthentication()` inside the service.
+
+---
+
+## CSRF — Disable It Only If No Cookie Carries Authentication
+
+Spring Security enables CSRF protection by default using `HttpSessionCsrfTokenRepository`.
+
+Disabling it is **legitimate** for a stateless API where every request is authenticated by
+an `Authorization: Bearer` header, because browsers do not attach that automatically. It is
+**not** legitimate if any session cookie still authenticates the user — that is the actual
+vulnerability, and `.csrf(csrf -> csrf.disable())` copied from a JWT tutorial into a
+cookie-session app is how it happens.
+
+```java
+// ✓ Stateless bearer-token API — no ambient credential, so no CSRF surface
+http.csrf(AbstractHttpConfigurer::disable)
+    .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+// ✓ Cookie-session SPA — keep CSRF on, expose the token to JS
+CsrfTokenRequestAttributeHandler handler = new CsrfTokenRequestAttributeHandler();
+handler.setCsrfRequestAttributeName(null);  // opt out of deferred/BREACH-encoded lookup
+http.csrf(csrf -> csrf
+    .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+    .csrfTokenRequestHandler(handler));
+```
+
+> Spring Security 6 defaults to `XorCsrfTokenRequestAttributeHandler` (BREACH mitigation),
+> which is why SPAs that worked on Spring Security 5 start returning 403 after an upgrade.
+> The handler above is the supported fix — do not "solve" it by disabling CSRF.
+
+---
+
+## SQL and JPQL Injection
+
+Derived query methods and bound `@Query` parameters are safe. Injection enters through the
+escape hatches, where the query is a runtime-built `String`.
+
+```java
+// ✓ Safe — derived from the method name, criteria built by Spring Data
+Optional<User> findByEmailIgnoreCase(String email);
+
+// ✓ Safe — named bind parameters (:email) and positional (?1) are both parameterised
+@Query("SELECT u FROM User u WHERE u.email = :email")
+Optional<User> lookup(@Param("email") String email);
+
+// ✓ Safe — native query, still parameterised
+@Query(value = "SELECT * FROM users WHERE email = :email", nativeQuery = true)
+Optional<User> lookupNative(@Param("email") String email);
+```
+
+```java
+// ✗ Injection — EntityManager with a concatenated string
+em.createQuery("SELECT u FROM User u WHERE u.name = '" + name + "'").getResultList();
+em.createNativeQuery("SELECT * FROM users WHERE name = '" + name + "'").getResultList();
+
+// ✗ Injection — JdbcTemplate with the value inlined
+jdbcTemplate.queryForObject("SELECT * FROM users WHERE id = " + id, mapper);
+
+// ✓ Safe — placeholders, values passed separately
+jdbcTemplate.queryForObject("SELECT * FROM users WHERE id = ?", mapper, id);
+namedJdbcTemplate.queryForObject("SELECT * FROM users WHERE id = :id",
+    Map.of("id", id), mapper);
+```
+
+**Sorting cannot be parameterised.** Spring Data validates `Sort` properties against the
+entity for derived and JPQL queries, but with `nativeQuery = true` the `ORDER BY` clause is
+appended to the SQL as supplied. Allow-list it:
+
+```java
+private static final Set<String> SORTABLE = Set.of("createdAt", "name");
+
+String field = SORTABLE.contains(requested) ? requested : "createdAt";
+```
+
+---
+
+## SpEL Injection — Spring-Specific, Reaches RCE
+
+Evaluating a user-controlled Spring Expression Language string is remote code execution, not
+a data leak. This is the class behind CVE-2018-1273 and repeated Spring Data CVEs.
+
+```java
+// ✗ RCE — T(java.lang.Runtime).getRuntime().exec("...") evaluates happily
+Object result = new SpelExpressionParser().parseExpression(userInput).getValue();
+
+// ✓ If expressions must be user-supplied, strip the dangerous surface
+EvaluationContext ctx = SimpleEvaluationContext.forReadOnlyDataBinding().build();
+Object result = new SpelExpressionParser()
+    .parseExpression(userInput).getValue(ctx);   // no type refs, no method invocation
+```
+
+`SimpleEvaluationContext` removes Java type references, constructors, and bean lookups.
+`StandardEvaluationContext` (the default) allows all three. Treat any user string that
+reaches `parseExpression`, a `@Query` SpEL fragment (`?#{...}`), or a `MessageSource`
+template as a code-execution sink.
+
+---
+
+## Mass Assignment — Never Bind a Request onto an Entity
+
+```java
+// ✗ Mass assignment — the client can POST role=ADMIN or enabled=true
+@PostMapping("/users")
+public User create(@ModelAttribute User user) {   // User is a JPA @Entity
+    return repository.save(user);
+}
+
+// ✓ Bind to a DTO exposing only client-settable fields, then map explicitly
+public record CreateUserRequest(
+    @NotBlank @Size(max = 100) String name,
+    @Email String email) { }
+
+@PostMapping("/users")
+public User create(@Valid @RequestBody CreateUserRequest req) {
+    User user = new User(req.name(), req.email());
+    user.setRole(Role.USER);          // server decides privileged fields
+    return repository.save(user);
+}
+```
+
+For Jackson-bound entities you cannot refactor yet, mark privileged fields
+`@JsonProperty(access = Access.READ_ONLY)`, and set
+`spring.jackson.deserialization.fail-on-unknown-properties=true` so unexpected fields fail
+loudly instead of binding silently.
+
+---
+
+## Deserialisation
+
+Jackson is safe until polymorphic typing is switched on globally — that turns any JSON body
+into a gadget-chain sink.
+
+```java
+// ✗ Deserialisation RCE — attacker controls the target class via the type field
+mapper.activateDefaultTyping(LaissezFaireSubTypeValidator.instance,
+    DefaultTyping.NON_FINAL);
+
+// ✓ Allow-list the permitted subtypes instead
+@JsonTypeInfo(use = Id.NAME, property = "type")
+@JsonSubTypes({ @Type(value = CardPayment.class, name = "card"),
+                @Type(value = BankPayment.class, name = "bank") })
+public sealed interface Payment permits CardPayment, BankPayment { }
+```
+
+Never deserialise untrusted bytes with `java.io.ObjectInputStream` — there is no safe
+configuration for it. Use JSON with a declared target type.
+
+---
+
+## Input Validation — `@Valid` Does Not Cover Params
+
+`@Valid` validates the annotated object (a `@RequestBody` DTO). Constraints placed directly
+on `@RequestParam` or `@PathVariable` are only enforced if the **class** is `@Validated`.
+
+```java
+// ✓ Both forms of validation wired up
+@RestController
+@Validated                                    // required for the @Min below to run
+public class SearchController {
+    @GetMapping("/search")
+    public List<Item> search(@RequestParam @Size(max = 100) String q,
+                             @RequestParam @Min(1) int page) { ... }
+
+    @PostMapping("/items")
+    public Item create(@Valid @RequestBody ItemRequest req) { ... }
+}
+```
+
+Handle both failure modes — `MethodArgumentNotValidException` (body) and
+`ConstraintViolationException` (params) — in `@RestControllerAdvice`, returning a generic
+message. Never echo the exception text: it leaks field names, SQL, and file paths.
+
+> **Kotlin:** annotations on a constructor `val` default to the constructor *parameter*, so
+> validation silently never runs. Use the `field:` use-site target:
+> `data class Req(@field:NotBlank val name: String)`. Kotlin's null-safety checks presence,
+> not content — it is not a substitute for constraints.
+
+---
+
+## XSS and Template Injection (Thymeleaf)
+
+```html
+<!-- ✓ th:text HTML-escapes -->
+<p th:text="${user.bio}">bio</p>
+
+<!-- ✗ th:utext writes raw markup — stored XSS on user input -->
+<p th:utext="${user.bio}">bio</p>
+```
+
+Sanitise with OWASP Java HTML Sanitizer before using `th:utext`. Separately, never build a
+**view name** from user input — Thymeleaf resolves fragment expressions in the view name,
+making it a server-side template injection sink:
+
+```java
+// ✗ SSTI — a view name like "__${T(java.lang.Runtime)...}__::x" executes
+return "user/" + request.getParameter("page");
+
+// ✓ Map input to a fixed set of view names
+return VIEWS.getOrDefault(request.getParameter("page"), "user/home");
+```
+
+---
+
+## CORS and Security Headers
+
+Spring 6 throws at startup on `allowedOrigins("*")` combined with `allowCredentials(true)`.
+The trap is the workaround: `allowedOriginPatterns("*")` permits exactly that combination
+and reflects every `Origin`.
+
+```java
+// ✗ Unsafe — reflects any origin back with credentials allowed
+config.setAllowedOriginPatterns(List.of("*"));
+config.setAllowCredentials(true);
+
+// ✓ Safe — explicit origins
+config.setAllowedOrigins(List.of("https://app.example.com"));
+config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+config.setAllowCredentials(true);
+```
+
+Spring Security sends `X-Content-Type-Options`, `X-Frame-Options: DENY`, and `Cache-Control`
+by default, and HSTS on HTTPS requests. **CSP is not set by default** — add it:
+
+```java
+http.headers(h -> h
+    .contentSecurityPolicy(csp -> csp.policyDirectives("default-src 'self'"))
+    .httpStrictTransportSecurity(hsts -> hsts
+        .includeSubDomains(true).maxAgeInSeconds(63072000))
+    .referrerPolicy(r -> r.policy(STRICT_ORIGIN_WHEN_CROSS_ORIGIN)));
+```
+
+---
+
+## Passwords and Secrets
+
+```java
+// ✓ DelegatingPasswordEncoder stores a {bcrypt} prefix, enabling algorithm migration
+@Bean
+PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+}
+
+// ✓ Explicit strength (default is 10) — or Argon2PasswordEncoder
+@Bean
+PasswordEncoder bcrypt() { return new BCryptPasswordEncoder(12); }
+
+// ✗ Never — NoOpPasswordEncoder stores plaintext; deprecated for exactly this reason
+NoOpPasswordEncoder.getInstance();
+```
+
+Hardcoded credentials in `application.yml` are not only committed to git — they are also
+readable through `/actuator/env` and `/configprops` if Actuator is exposed. Resolve secrets
+from the environment or a secrets manager:
+
+```yaml
+# ✓ application.yml holds a reference, never the value
+spring:
+  datasource:
+    password: ${DB_PASSWORD}          # fails fast at startup if unset
+  cloud:
+    vault:
+      host: vault.internal.example.com   # host and port are separate properties
+      port: 8200
+      scheme: https
+      authentication: KUBERNETES
+```
+
+---
+
+## Path Traversal and SSRF
+
+```java
+// ✓ Normalise, then confirm the resolved path is still inside the base directory
+Path base = Paths.get("/srv/uploads").toAbsolutePath().normalize();
+Path target = base.resolve(userFilename).normalize();
+if (!target.startsWith(base)) throw new AccessDeniedException("path traversal");
+
+// ✗ SSRF — a user-supplied URL reaches internal services and cloud metadata
+restTemplate.getForObject(userSuppliedUrl, String.class);
+// ✓ Allow-list the host and block private/link-local ranges (169.254.169.254, 10/8, 127/8, ::1)
+```
+
+---
+
+## ASVS Controls for Spring Boot Projects
+
+| ASVS Ref | Control | Spring Implementation |
+|----------|---------|-----------------------|
+| V8.3.1 | Auth on all endpoints | Filter chain ending `.anyRequest().authenticated()` |
+| V8.2.2 | Object-level authorisation | Ownership scoped into the repository query |
+| V2.2.1 | Input validation | `@Valid` on DTOs; `@Validated` on the class for params |
+| V1.2.4 | No SQL injection | Derived queries / bound `@Query` params; never concatenate |
+| V1.3.1 | Output encoding (XSS) | Thymeleaf `th:text`; sanitise before `th:utext` |
+| V11.4.2 | Password storage | `DelegatingPasswordEncoder` → BCrypt (strength ≥ 12) or Argon2 |
+| V3.5.1 | CSRF | Enabled by default; `CookieCsrfTokenRepository` for SPAs |
+| V4.1.1 | Security headers | `HeadersConfigurer` — CSP must be added explicitly |
+| V14.1.1 | Don't confirm resource existence | Return 404, not 403, for records the caller can't see |
+| V16.3.1 | Auth event logging | `AuthenticationSuccess`/`FailureEvent` listeners |
+
+---
+
+## Recommended Security Tooling (2026)
+
+| Category | Tool |
+|----------|------|
+| SAST | SpotBugs + `find-sec-bugs`, Semgrep (Java/Kotlin rules) |
+| Vulnerable dependencies | OWASP Dependency-Check, Snyk, `gradle dependencyCheckAnalyze` |
+| Dependency currency | Keep `spring-boot-starter-parent` / the Spring BOM current — it pins transitive versions |
+| Secret scanning | gitleaks |
+| Kotlin lint | detekt (with the `detekt-rules` security ruleset) |
+| HTML sanitisation | OWASP Java HTML Sanitizer |
+| Password hashing | `BCryptPasswordEncoder`, `Argon2PasswordEncoder` (needs BouncyCastle) |
+| Runtime hardening | Actuator on an internal-only management port |

--- a/test/consistency.test.js
+++ b/test/consistency.test.js
@@ -17,7 +17,11 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const stacksDir = join(ROOT, "stacks");
 
 // Frameworks that ship BOTH a notes entry and a stacks/<name>.md profile.
-const PROFILED_FRAMEWORKS = ["nextjs", "express", "django", "fastapi", "rails", "golang"];
+const PROFILED_FRAMEWORKS = ["nextjs", "express", "django", "fastapi", "rails", "golang", "spring-boot"];
+
+// stacks/nodejs.md is a fallback pointer for "Node, framework unknown" rather than a
+// framework profile, so it intentionally has no dedicated notes entry.
+const FALLBACK_PROFILES = ["nodejs"];
 
 test("each profiled framework has at least 4 security notes", () => {
   for (const name of PROFILED_FRAMEWORKS) {
@@ -64,6 +68,24 @@ test("every stacks/*.md profile is non-empty and has an H1 title", () => {
   }
 });
 
+// Every profile we ship must have real notes — not the generic fallback. This is the
+// exact gap that let `spring-boot` be detectable with no guidance behind it.
+test("every shipped profile has stack-specific notes, not the generic fallback", () => {
+  const generic = getStackSecurityNotes("a-stack-that-does-not-exist");
+  const shipped = readdirSync(stacksDir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => f.replace(/\.md$/, ""))
+    .filter((name) => !FALLBACK_PROFILES.includes(name));
+
+  for (const name of shipped) {
+    assert.notDeepEqual(
+      getStackSecurityNotes(name),
+      generic,
+      `stacks/${name}.md ships but getStackSecurityNotes("${name}") returns the generic fallback`
+    );
+  }
+});
+
 test("detectStack identifies frameworks from manifest files", () => {
   const cases = [
     { files: { "package.json": JSON.stringify({ dependencies: { next: "14" } }) }, expect: "nextjs" },
@@ -72,6 +94,13 @@ test("detectStack identifies frameworks from manifest files", () => {
     { files: { "go.mod": "module x\n" }, expect: "golang" },
     { files: { "requirements.txt": "fastapi==0.110" }, expect: "fastapi" },
     { files: { "Gemfile": "gem 'rails'" }, expect: "rails" },
+    // Maven names the starter artifact; Gradle applies the org.springframework.boot plugin.
+    { files: { "pom.xml": "<artifactId>spring-boot-starter-web</artifactId>" }, expect: "spring-boot" },
+    { files: { "build.gradle": "plugins { id 'org.springframework.boot' version '3.2.0' }" }, expect: "spring-boot" },
+    { files: { "build.gradle.kts": `plugins { id("org.springframework.boot") version "3.2.0" }` }, expect: "spring-boot" },
+    // Plain JVM projects must NOT inherit the Spring Boot profile.
+    { files: { "pom.xml": "<artifactId>plain-java-app</artifactId>" }, expect: "java" },
+    { files: { "build.gradle.kts": `plugins { kotlin("jvm") version "1.9.0" }` }, expect: "java" },
   ];
   for (const { files, expect } of cases) {
     const dir = mkdtempSync(join(tmpdir(), "stackdetect-"));


### PR DESCRIPTION
Adds stacks/spring-boot.md (Spring Boot 3.x / Spring Security 6.x, Java + Kotlin) and its getStackSecurityNotes() entry. Fixes Gradle detection, which always resolved to "java" so Kotlin/Gradle Spring projects never reached the profile. Adds .github/workflows/pr-checks.yml so fork PRs are validated — CircleCI skips them unless "Build forked pull requests" is on.

Bumps to 1.3.0 and realigns package-lock.json, which had drifted to 1.1.0.