### PR TITLE
fix: upgrade fast-uri to 4.0.1, 3.1.3, 2.4.2 (CVE-2026-13676)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
+        "fast-uri": "^3.1.3",
         "inquirer": "^9.2.0",
         "ora": "^8.0.0"
       },
@@ -687,9 +688,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
+    "fast-uri": "^3.1.3",
     "inquirer": "^9.2.0",
     "ora": "^8.0.0"
   }


### PR DESCRIPTION
## Summary
Upgrade fast-uri from 3.1.2 to 4.0.1, 3.1.3, 2.4.2 to fix CVE-2026-13676.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-13676 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-13676` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: fast-uri: fast-uri: Security policy bypass due to improper Unicode hostname canonicalization

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-13676` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `package.json`
- `package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
