### PR TITLE
Fix/fast uri advisories

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "A team of 8 AI security specialists embedded in your coding workflow — covering every phase of the Secure SDLC from requirements to release gating.",
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "Kaademos/secure-sdlc-agents"
       },
       "description": "8 AI security specialist agents for the full Secure SDLC: threat modelling, AppSec, GRC, IaC review, AI/LLM security, and release gating. Works with Claude Code, Cursor, Windsurf, and any MCP-compatible tool.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "Kaademos"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "secure-sdlc-agents",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A team of AI security specialists embedded in your coding workflow. 8 agents covering every phase of the Secure SDLC: requirements, threat modelling, code review, IaC security, compliance, and release gating. Works with Claude Code, Cursor, Windsurf, and any MCP-compatible tool.",
   "author": {
     "name": "Kaademos",

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,61 @@
+name: Dependency Audit
+
+# Runs `npm audit` against the committed lockfile.
+#
+# WHY THIS IS SEPARATE FROM pr-checks.yml:
+# A pull-request-only audit would not have caught GHSA-4c8g-83qw-93j6 /
+# GHSA-v2hh-gcrm-f6hx (fast-uri, fixed in v1.3.1). That advisory was published
+# against a dependency tree nobody had touched — there was no PR to attach a
+# check to, so an outside contributor found it before we did. The `schedule`
+# trigger below is the part that actually closes that gap; the `pull_request`
+# trigger just stops a PR from introducing something new.
+#
+# GATE LEVEL: `high`. Gating at `moderate` would fail today on
+# GHSA-frvp-7c67-39w9 (@hono/node-server serve-static path traversal), which is
+# not reachable here — the MCP server is stdio-only and never imports hono — and
+# which cannot be patched without forcing a major version outside the range
+# @modelcontextprotocol/sdk declares. Moderates are still printed, just not
+# fatal. Revisit the level once that one clears.
+#
+# NOTE: repository CI, not shipped to end users. package.json `files` includes
+# only .github/workflows/secure-sdlc-gate.yml, which is the product template.
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays, 09:00 UTC. Scheduled runs only fire on the default branch, and
+    # GitHub disables them after 60 days without repository activity.
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-audit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: npm audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      # --package-lock-only resolves advisories straight from the committed
+      # lockfile, so no dependency is installed or executed to run the audit.
+      - name: Report all advisories
+        run: npm audit --package-lock-only || true
+
+      - name: Fail on high or critical advisories
+        run: npm audit --audit-level=high --package-lock-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.3.1] — 2026-07-22
+
+### Security
+- **`fast-uri` upgraded to 3.1.4** via an `overrides` entry, clearing two HIGH advisories in the transitive `@modelcontextprotocol/sdk → ajv → fast-uri` chain:
+  - [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) / CVE-2026-13676 — host confusion via failed IDN canonicalization (fixed in 3.1.3)
+  - [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) / CVE-2026-16221 — host confusion via literal backslash authority delimiter (fixed in 3.1.4)
+
+  Reported by @anupamme in #17, which targeted 3.1.3 and so would have left the second advisory open. `overrides` is used rather than a direct dependency because nothing in this codebase imports `fast-uri`; it also keeps the floor in place across future `npm update` runs. Note that `overrides` applies to this repository's own installs (CI, clones, development) — consumers of the published package resolve `fast-uri` through ajv's `^3.0.1` range, which already yields a patched version.
+
+### Notes
+- `@hono/node-server` (GHSA-frvp-7c67-39w9, moderate — `serve-static` path traversal on Windows) remains open and is **not reachable in this project**: the MCP server uses `StdioServerTransport` only and never imports hono or `serve-static`. Patching requires `>=2.0.5`, outside the `^1.19.9` range `@modelcontextprotocol/sdk` declares, so forcing it would risk breaking the SDK for no security benefit. Revisit when the SDK widens its range.
+
+---
+
 ## [1.3.0] — 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   Reported by @anupamme in #17, which targeted 3.1.3 and so would have left the second advisory open. `overrides` is used rather than a direct dependency because nothing in this codebase imports `fast-uri`; it also keeps the floor in place across future `npm update` runs. Note that `overrides` applies to this repository's own installs (CI, clones, development) — consumers of the published package resolve `fast-uri` through ajv's `^3.0.1` range, which already yields a patched version.
 
+### Added
+- **Dependency audit CI** (`.github/workflows/dependency-audit.yml`) — `npm audit` on every PR **and on a weekly schedule**, failing on high/critical while still reporting moderates. The schedule is the part that matters: the `fast-uri` advisories landed against a dependency tree nobody had touched, so there was no PR for a check to attach to. Runs `--package-lock-only`, so no dependency is installed or executed to perform the audit
+
 ### Notes
 - `@hono/node-server` (GHSA-frvp-7c67-39w9, moderate — `serve-static` path traversal on Windows) remains open and is **not reachable in this project**: the MCP server uses `StdioServerTransport` only and never imports hono or `serve-static`. Patching requires `>=2.0.5`, outside the `^1.19.9` range `@modelcontextprotocol/sdk` declares, so forcing it would risk breaking the SDK for no security benefit. Revisit when the SDK widens its range.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,11 @@ Every pull request, including one opened from a fork, is checked automatically b
 matrix. CircleCI (`.circleci/config.yml`) covers pushes to `main` and release tags.
 If your PR is red, run `npm run ci` locally to reproduce it before pushing a fix.
 
+[`.github/workflows/dependency-audit.yml`](.github/workflows/dependency-audit.yml) runs
+`npm audit` on each PR and weekly, failing on high or critical advisories. Reproduce it
+with `npm audit --audit-level=high`. Prefer an `overrides` entry for a transitive
+dependency over adding a direct one the code does not import.
+
 Maintainers: see [RELEASING.md](RELEASING.md) for how to cut a release.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kaademos/secure-sdlc",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kaademos/secure-sdlc",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -687,9 +687,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaademos/secure-sdlc",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Secure SDLC agent team — CLI to scaffold docs, hooks, CI, and MCP-ready security workflows",
   "type": "module",
   "bin": {
@@ -67,5 +67,8 @@
     "commander": "^12.0.0",
     "inquirer": "^9.2.0",
     "ora": "^8.0.0"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.4"
   }
 }


### PR DESCRIPTION
## Description

Clears GHSA-4c8g-83qw-93j6 (CVE-2026-13676) and GHSA-v2hh-gcrm-f6hx
(CVE-2026-16221) in the transitive sdk -> ajv -> fast-uri chain. Uses
overrides rather than a direct dependency since nothing here imports
fast-uri. Reported by @anupamme in #17, which targeted 3.1.3 and would
have left the second advisory open.

added scheduled npm audit gating on high advisories

Runs npm audit on PRs and weekly, failing on high/critical while still
reporting moderates. The schedule is the point: the fast-uri advisories
landed against an untouched dependency tree, so no PR check would have
caught them. Gate is high rather than moderate because the unreachable
@hono/node-server advisory cannot be patched within the SDK's declared
range.
